### PR TITLE
Update Get-MMSSessionContent.ps1

### DIFF
--- a/Get-MMSSessionContent.ps1
+++ b/Get-MMSSessionContent.ps1
@@ -20,6 +20,7 @@
     Chris Kibble - https://www.christopherkibble.com
     Jon Warnken - https://www.mrbodean.net
     Oliver Baddeley - Edited for Desert Edition
+    Benjamin Reynolds - https://sqlbenjamin.wordpress.com/
 
 
 
@@ -43,187 +44,175 @@
 #>
 
 
+[cmdletbinding(PositionalBinding=$false)]
 Param(
-  $DownloadLocation = "C:\Conferences\MMS",
-  $ConferenceYears = (Get-Date).year,
-  $All = $false
+  [Parameter(Mandatory=$false)][string]$DownloadLocation = "C:\Conferences\MMS", # could validate this: [ValidateScript({(Test-Path -Path (Split-Path $PSItem))})]
+  [Parameter(Mandatory=$false,ParameterSetName='SingleEvent')]
+  [ValidateSet("2015","2016","2017","2018","de2018","2019","jazz","miami")]
+  [string]$ConferenceId,
+  [Parameter(Mandatory=$false,ParameterSetName='AllEvents')][switch]$All,
+  [Parameter(Mandatory=$false)][switch]$IncludeSessionDetails # should this be the default rather than not?
 )
 
-$PublicContentYears = @('2015', '2016', '2017')
-$PrivateContentYears = @('2018', 'de2018', '2019', 'jazz', 'miami')
+## Make sure there aren't any trailing backslashes:
+$DownloadLocation = $DownloadLocation.Trim('\');
 
-if ($All -eq $true) {
-  $ConferenceYears = $PublicContentYears + $PrivateContentYears
-  $ConferenceYearsPublic = $PublicContentYears
-  $ConferenceYearsPrivate = $PrivateContentYears
+## Setup
+$PublicContentYears = @('2015', '2016', '2017');
+$PrivateContentYears = @('2018', 'de2018', '2019', 'jazz', 'miami');
+$ConferenceYears = New-Object -TypeName System.Collections.Generic.List[string];
+[int]$PublicYearsCount = $PublicContentYears.Count;
+[int]$PrivateYearsCount = $PrivateContentYears.Count;
+
+if ($All) {
+  for ($i = 0;$i -lt $PublicYearsCount;$i++)
+  {
+    $ConferenceYears.Add($PublicContentYears[$i]);
+  }
+  Remove-Variable -Name i -ErrorAction SilentlyContinue;
+  for ($i = 0;$i -lt $PrivateYearsCount;$i++)
+  {
+    $ConferenceYears.Add($PrivateContentYears[$i]);
+  }
+  Remove-Variable -Name i -ErrorAction SilentlyContinue;
+}
+else
+{
+  $ConferenceYears.Add($ConferenceId);
 }
 
 Write-Output "Base Download URL is $DownloadLocation"
 Write-Output "Searching for content from these sessions: $([String]::Join(',',$ConferenceYears))"
 
-$ConferenceYearsPublic = $ConferenceYears | Where-Object { $_ -notin $PrivateContentYears }
-$ConferenceYearsPrivate = $ConferenceYears | Where-Object { $_ -notin $PublicContentYears }
+## 
+$ConferenceYears | ForEach-Object -Process {
+  [string]$Year = $_;
+  
+  if ($Year -in $PrivateContentYears)
+  {
+    $creds = $host.UI.PromptForCredential('Sched Credentials', "Enter Credentials for the MMS Event: $Year", '', '');
+  }
 
-if ($ConferenceYearsPrivate.count -gt 0) {
-  $c = $host.UI.PromptForCredential('Sched Credentials', 'Enter Credentials', '', '')
-  foreach ($year in $ConferenceYearsPrivate) {
-    $SchedBaseURL = "https://mms" + $Year + ".sched.com"
-    $SchedLoginURL = $SchedBaseURL + "/login"
-    Add-Type -AssemblyName System.Web
-    $web = Invoke-WebRequest $SchedLoginURL -SessionVariable mms
+  $SchedBaseURL = "https://mms" + $Year + ".sched.com";
+  $SchedLoginURL = $SchedBaseURL + "/login"; ## does the public one have the same url?
+  Add-Type -AssemblyName System.Web;
+  $web = Invoke-WebRequest $SchedLoginURL -SessionVariable mms;
+  if ($creds)
+  {
     $form = $web.Forms[1]
-    $form.fields['username'] = $c.UserName
-    $form.fields['password'] = $c.GetNetworkCredential().Password
-    $SessionDownloadPath = $DownloadLocation + '\mms' + $Year
+    $form.fields['username'] = $creds.UserName;
+    $form.fields['password'] = $creds.GetNetworkCredential().Password;
+  }
 
-    "Logging in to $SchedBaseURL"
+  $SessionDownloadPath = $DownloadLocation + '\mms' + $Year;
+  Write-Output "Logging in to $SchedBaseURL";
 
+  ## I don't care about the dates...let's just get all sessions for the entire conference rather than look at them by date...
 
-    $mmsHome = Invoke-WebRequest $SchedBaseURL -WebSession $mms
+  ## Connect to Sched
+  if ($form)
+  {
+    $web = Invoke-WebRequest $SchedLoginURL -WebSession $mms -Method POST -Body $form.Fields;
+  }
+  else
+  {
+    $web = Invoke-WebRequest $SchedLoginURL -WebSession $mms;
+  }
+  ## Check if we connected (if required):
+  if ((-Not ($web.InputFields.FindByName("login")) -and ($Year -in $PrivateContentYears)) -or ($Year -in $PublicContentYears)) {
+    ##
+    Write-Output "Downloaded content can be found in $SessionDownloadPath";
 
-    $htmlDate = $mmsHome.ParsedHtml.IHTMLDocument3_GetElementById('sched-sidebar-filters-dates')
-    $htmlPopoverBody = $htmlDate.getElementsByClassName('popover')
-    $htmlDateList = $htmlPopoverBody[0].getElementsByTagName('li')
+    $sched = Invoke-WebRequest -Uri $($SchedBaseURL + "/list/descriptions") -WebSession $mms;
+    $links = $sched.Links;
 
-    $MMSDates = @()
-    $htmlDateList | ForEach-Object {
-      out-null -InputObject  $($_.innerHTML -match "\d{4}-\d{2}-\d{2}")
-      $MMSDates += $matches[0]
-    }
-    $web = Invoke-WebRequest $SchedLoginURL -WebSession $mms -Method POST -Body $form.Fields
-    if (-Not ($web.InputFields.FindByName("login"))) {
-      Write-Output "Downloaded content can be found in $SessionDownloadPath"
-      ForEach ($Date in $MMSDates) {
-        "Checking day '{0}' for downloads" -f $Date
-        $sched = Invoke-WebRequest -Uri $($SchedBaseURL + "/" + $Date + "/list/descriptions") -WebSession $mms
+    $eventsList = New-Object -TypeName System.Collections.Generic.List[int];
 
-        $links = $sched.Links
-        $eventsIndex = @()
-        $links | ForEach-Object { if (($_.href -like "event/*") -and ($_.innerText -notlike "here")) {
-            $eventsIndex += (, ($links.IndexOf($_), $_.innerText))
-          } }
-        $i = 0
-        While ($i -lt $eventsIndex.Count) {
-          $eventTitle = $eventsIndex[$i][1]
-          $eventTitle = $eventTitle -replace "[^A-Za-z0-9-_. ]", ""
-          $eventTitle = $eventTitle.Trim()
-          $eventTitle = $eventTitle -replace "\W+", "_"
-          $links[$eventsIndex[$i][0]..$(if ($i -eq $eventsIndex.Count - 1) { $links.Count - 1 } else { $eventsIndex[$i + 1][0] })] | ForEach-Object {
-            if ($_.href -like "*hosted_files*") {
-              $downloadPath = $DownloadLocation + '\mms' + $Year + '\' + $Date + '\' + $eventTitle
-              $filename = $_.href
-              $filename = $filename.substring(40)
-              # Replace HTTP Encoding Characters (e.g. %20) with the proper equivalent.
-              $filename = [System.Web.HttpUtility]::UrlDecode($filename)
-              # Replace non-standard characters
-              $filename = $filename -replace "[^A-Za-z0-9\.\-_ ]", ""
-              # Remove 7 characters added to filenames in 2019
-              $filename = $filename.Substring(7)
-              $outputFilePath = $downloadPath + '\' + $filename
-              # Reduce Total Path to 255 characters.
-              $outputFilePathLen = $outputFilePath.Length
-
-              If ($outputFilePathLen -ge 255) {
-                $fileExt = [System.IO.Path]::GetExtension($outputFilePath)
-                $newFileName = $outputFilePath.Substring(0, $($outputFilePathLen - $fileExt.Length))
-                $newFileName = $newFileName.Substring(0, $(255 - $fileExt.Length)).trim()
-                $newFileName = "$newFileName$fileExt"
-                $outputFilePath = $newFileName
-              }
-
-              if ((Test-Path -Path $($downloadPath)) -eq $false) { New-Item -ItemType Directory -Force -Path $downloadPath | Out-Null }
-              if ((Test-Path -Path $outputFilePath) -eq $false) {
-                "...attempting to download '{0}'" -f $filename
-                Invoke-WebRequest -Uri $_.href -OutFile $outputfilepath -WebSession $mms
-                Unblock-File $outputFilePath
-              }
-            }
-          }
-
-          $i++
-        }
+    $links | ForEach-Object -Process {
+      if ($_.href -like "event/*")
+      {
+          [void]$eventsList.Add($links.IndexOf($_));
       }
     }
-    else {
-      "Login to $SchedBaseUrl failed."
-    }
-  }
-}
 
-foreach ($year in $ConferenceYearsPublic) {
-  $SchedBaseURL = "https://mms" + $Year + ".sched.com"
-  $SchedLoginURL = $SchedBaseURL
-  Add-Type -AssemblyName System.Web
-  $web = Invoke-WebRequest $SchedLoginURL -SessionVariable mms
-  $SessionDownloadPath = $DownloadLocation + '\mms' + $Year
+    [int]$eventCount = $eventsList.Count;
 
-  "Logging in to $SchedBaseURL"
+    for ($i = 0; $i -lt $eventCount; $i++)
+    {
+      [int]$linkIndex = $eventsList[$i];
+      [int]$nextLinkIndex = $eventsList[$i+1];
+      [string]$sessionInfoText = "";
+      
+      ## Get/Fix the Session Title:
+      [string]$eventTitle = $links[$linkIndex].innerText;
+      ## testing Write-output $eventTitle
+      $sessionInfoText += "Session Title:`r`n$eventTitle`r`n`r`n";
+      $eventTitle = $eventTitle -replace "[^A-Za-z0-9-_. ]", "";
+      $eventTitle = $eventTitle.Trim();
+      $eventTitle = $eventTitle -replace "\W+", "_";
 
+      ## Set the download destination:
+      $downloadPath = $SessionDownloadPath + '\' + $eventTitle;
 
-  $mmsHome = Invoke-WebRequest $SchedBaseURL -WebSession $mms
+      ## Get Session information if required:
+      if ($IncludeSessionDetails)
+      {
+        $sessionLinkInfo = Invoke-WebRequest -Uri $($SchedBaseURL + "/" + $links[$linkIndex].href) -WebSession $mms;
+        
+        $sessionLinkInfo.ParsedHtml.getElementsByTagName("div") | ForEach-Object {
+          if ($_.className -eq 'tip-description')
+          {
+            $sessionInfoText += "$($_.outerText)`r`n`r`n";
+          }
+          if ($_.className -eq 'tip-roles')
+          {
+            $sessionInfoText += "$($_.outerText)`r`n`r`n";
+          }
+        } # end of Foreach-Object processing the div tags to get the classes
 
-  $htmlDate = $mmsHome.ParsedHtml.IHTMLDocument3_GetElementById('sched-sidebar-filters-dates')
-  $htmlPopoverBody = $htmlDate.getElementsByClassName('popover')
-  $htmlDateList = $htmlPopoverBody[0].getElementsByTagName('li')
-
-  $MMSDates = @()
-  $htmlDateList | ForEach-Object {
-    out-null -InputObject  $($_.innerHTML -match "\d{4}-\d{2}-\d{2}")
-    $MMSDates += $matches[0]
-  }
-
-  $web = Invoke-WebRequest $SchedLoginURL -WebSession $mms
-  Write-Output "Downloaded content can be found in $SessionDownloadPath"
-  ForEach ($Date in $MMSDates) {
-    "Checking day '{0}' for downloads" -f $Date
-
-    $sched = Invoke-WebRequest -Uri $($SchedBaseURL + "/" + $Date + "/list/descriptions") -WebSession $mms
-
-    $links = $sched.Links
-    $eventsIndex = @()
-    $links | ForEach-Object { if (($_.href -like "event/*") -and ($_.innerText -notlike "here")) {
-        $eventsIndex += (, ($links.IndexOf($_), $_.innerText))
-      } }
-    $i = 0
-    While ($i -lt $eventsIndex.Count) {
-      $eventTitle = $eventsIndex[$i][1]
-      $eventTitle = $eventTitle -replace "[^A-Za-z0-9-_. ]", ""
-      $eventTitle = $eventTitle.Trim()
-      $eventTitle = $eventTitle -replace "\W+", "_"
-      $links[$eventsIndex[$i][0]..$(if ($i -eq $eventsIndex.Count - 1) { $links.Count - 1 } else { $eventsIndex[$i + 1][0] })] | ForEach-Object {
-
-        if ($_.href -like "*hosted_files*") {
-          $downloadPath = $DownloadLocation + '\mms' + $Year + '\' + $Date + '\' + $eventTitle
-          $filename = $_.href
-          $filename = $filename.substring(40)
+        if ((Test-Path -Path $($downloadPath)) -eq $false) { New-Item -ItemType Directory -Force -Path $downloadPath | Out-Null }
+        Out-File -FilePath "$downloadPath\Session Info.txt" -InputObject $sessionInfoText -Force -Encoding default;
+      }
+      
+      ## Get/Fix/Download any files uploaded for the current session:
+      $links[($linkIndex+1)..($nextLinkIndex-1)] | ForEach-Object -Process {
+        if ($_.href -like "*hosted_files*")
+        {
+          $filename = Split-Path $_.href -Leaf;
           # Replace HTTP Encoding Characters (e.g. %20) with the proper equivalent.
-          $filename = [System.Web.HttpUtility]::UrlDecode($filename)
+          $filename = [System.Web.HttpUtility]::UrlDecode($filename);
           # Replace non-standard characters
-          $filename = $filename -replace "[^A-Za-z0-9\.\-_ ]", ""
+          $filename = $filename -replace "[^A-Za-z0-9\.\-_ ]", "";
+          
+          <# Is this still true or only required for 2019 cause I don't see anything prefixed to miami files...
           # Remove 7 characters added to filenames in 2019
           $filename = $filename.Substring(7)
-          $outputFilePath = $downloadPath + '\' + $filename
+          #>
+          
+          $outputFilePath = $downloadPath + '\' + $filename;
+          
           # Reduce Total Path to 255 characters.
-          $outputFilePathLen = $outputFilePath.Length
-
-          If ($outputFilePathLen -ge 255) {
+          $outputFilePathLen = $outputFilePath.Length;
+          if ($outputFilePathLen -ge 255) {
             $fileExt = [System.IO.Path]::GetExtension($outputFilePath)
             $newFileName = $outputFilePath.Substring(0, $($outputFilePathLen - $fileExt.Length))
             $newFileName = $newFileName.Substring(0, $(255 - $fileExt.Length)).trim()
             $newFileName = "$newFileName$fileExt"
             $outputFilePath = $newFileName
           }
-
+          
           if ((Test-Path -Path $($downloadPath)) -eq $false) { New-Item -ItemType Directory -Force -Path $downloadPath | Out-Null }
           if ((Test-Path -Path $outputFilePath) -eq $false) {
-            "...attempting to download '{0}'" -f $filename
-            Invoke-WebRequest -Uri $_.href -OutFile $outputfilepath -WebSession $mms
-            Unblock-File $outputFilePath
+            Write-Output "...attempting to download '$filename'";
+            Invoke-WebRequest -Uri $_.href -OutFile $outputfilepath -WebSession $mms;
+            Unblock-File $outputFilePath;
           }
         }
-      }
-
-      $i++
-    }
+      } # end of Foreach-Object: processing download files
+    } # end of for loop processing every session
+  } # end of if we successfully logged in if required
+  else
+  {
+    Write-Output "Login to $SchedBaseUrl failed.";
   }
 }


### PR DESCRIPTION
Funny, I was looking at doing something like this last week and saw your twitter post about it so took a look. The proposed changes just simplify it a little and also allow to create a "Session Info.txt" file with some details about each session inside the folders - which I thought could be handy. I think it could be even better by removing the cabana type sessions...but didn't look to see if all conferences use the same format or not so figured having them wouldn't be that big of a deal for now. Whatcha think?